### PR TITLE
Fix Jest CLI error causing Jest tests to not run (using Jest CLI v 0.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "js"
     ],
     "verbose": true,
-    "collectCoverage": true
+    "collectCoverage": true,
+    "modulePathIgnorePatterns": ["read-package-tree"]
   },
   "dependencies": {
     "es6-promise": "^3.0.2",


### PR DESCRIPTION
There is an error when running `npm test` using Jest CLI v.0.7.1

It is due to how package.json is being used in the dependency `read-package-tree`.  This should be excluded from the test suite.

Before: Test suite does not run
After: Test suite runs and successfully passes
