### PR TITLE
Remove use strict

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import App from './common/components/App';
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
Babel prepends "use strict" to compiled source files so this line is unnecessary
