### PR TITLE
migrate .eslintrc file to ESLint v2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,10 +14,12 @@
     "browser": true,
     "jest": true
   },
-  "ecmaFeatures": {
-    "jsx": true,
-    "experimentalObjectRestSpread": true,
-    "modules": true
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true,
+      "experimentalObjectRestSpread": true
+    },
+    "sourceType": "module"
   },
   "plugins": [
     "react"


### PR DESCRIPTION
ESLInt has updated to v2 and there're some significant changes (http://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options). There're some ESLint warning with the current .eslintrc and update the option will solve those warnings.