### PR TITLE
default export set

### DIFF
--- a/src/common/actions/CalculatorActions.js
+++ b/src/common/actions/CalculatorActions.js
@@ -3,7 +3,7 @@
 import AppDispatcher from '../dispatcher/AppDispatcher';
 import CalculatorConstants from '../constants/CalculatorConstants';
 
-var CalculatorActions = {
+const CalculatorActions = {
 
   typeKey: function(keyType, keyValue) {
     AppDispatcher.dispatch({
@@ -22,4 +22,4 @@ var CalculatorActions = {
 
 };
 
-module.exports = CalculatorActions;
+export default CalculatorActions;


### PR DESCRIPTION
previous method does not allow flexible import of "CalculatorActions" in other components
we strictly had to import "CalculatorActions" with the same name but the changes made allow us to import CalculatorActions with any name in any component